### PR TITLE
Enabled managed mode injection

### DIFF
--- a/_python2/airpwn-ng
+++ b/_python2/airpwn-ng
@@ -1,4 +1,4 @@
-#! /usr/bin/python2.7
+#! /usr/bin/python2
 import argparse
 import logging
 import os


### PR DESCRIPTION
It had been pointed out that WEP was broken in the _python2 setup for airpwn-ng.  While this commit does not fix the WEP injection issue it does provide a workaround in that you can now use --inj man as a workaround while WEP is being fixed.